### PR TITLE
Unnecessary usage of self in the guides

### DIFF
--- a/guides/source/active_record_callbacks.md
+++ b/guides/source/active_record_callbacks.md
@@ -68,7 +68,7 @@ class User < ActiveRecord::Base
 
   protected
     def normalize_name
-      self.name = self.name.downcase.titleize
+      self.name = name.downcase.titleize
     end
 
     def set_location


### PR DESCRIPTION
I deleted self from the callbacks guides code example because it's unnecessary and this way it's more like the other examples where self was not used.
